### PR TITLE
Add git-hours caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This composite GitHub Action calculates coding hours across one or more reposito
 | `window_start` | No | – | Optional start date (`YYYY‑MM‑DD`) passed to `git‑hours -since` to limit the reporting window. |
 | `metrics_branch` | No | `metrics` | The branch where the JSON reports are committed. |
 | `pages_branch` | No | `gh-pages` | The branch where the generated KPI website is committed (enables GitHub Pages). |
+| `git_hours_version` | No | `v0.1.2` | git-hours release tag to install and cache. |
 
 ## Outputs
 
@@ -55,7 +56,7 @@ This workflow triggers manually through the GitHub UI. When run, it computes cod
 
 ## Notes
 
-* The action installs a specific version of `git‑hours` (v0.1.2) using Go 1.24 and executes a Python helper script. If you want to update the version, modify the clone command in `action.yml` accordingly.
+* The action installs a specific version of `git‑hours` (controlled by the `git_hours_version` input) using Go 1.24 and executes a Python helper script.
 * Both branches (`metrics_branch` and `pages_branch`) are created automatically if they do not exist. Subsequent runs will update the existing branches without force‑pushing unless a non‑fast‑forward update is required.
 
 ## Development and Release

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: Branch to which the generated KPI site will be committed (for GitHub Pages).
     default: gh-pages
     required: false
+  git_hours_version:
+    description: git-hours release tag to install
+    default: v0.1.2
+    required: false
 outputs:
   aggregated_report:
     description: Path to the aggregated JSON report file
@@ -33,15 +37,28 @@ runs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    # Install Go for git-hours. Always use version 1.24 to match the git-hours v0.1.2 requirement.
+    # Install Go for git-hours. Always use version 1.24 to match the git-hours requirement.
     - name: Setup Go
       uses: actions/setup-go@v4
       with:
         go-version: '1.24'
-    # Install the specific git-hours release (v0.1.2) by cloning and go installing it.
-    - name: Install git-hours v0.1.2
+    # Determine GOPATH so we can cache the git-hours binary.
+    - name: Get GOPATH
+      id: go-env
+      run: echo "gopath=$(go env GOPATH)" >> "$GITHUB_OUTPUT"
+      shell: bash
+    # Cache the git-hours binary based on version and OS.
+    - name: Cache git-hours
+      id: cache-git-hours
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.go-env.outputs.gopath }}/bin/git-hours
+        key: git-hours-${{ inputs.git_hours_version }}-${{ runner.os }}
+    # Install git-hours if not restored from cache.
+    - name: Install git-hours
+      if: steps.cache-git-hours.outputs.cache-hit != 'true'
       run: |
-        git clone --depth 1 --branch v0.1.2 https://github.com/trinhminhtriet/git-hours.git git-hours-src
+        git clone --depth 1 --branch ${{ inputs.git_hours_version }} https://github.com/trinhminhtriet/git-hours.git git-hours-src
         # The module declares Go 1.24.1; adjust it to 1.24 for compatibility.
         sed -i 's/go 1.24.1/go 1.24/' git-hours-src/go.mod
         (cd git-hours-src && go install .)


### PR DESCRIPTION
## Summary
- add `git_hours_version` input
- cache git-hours binary
- document the new input

## Testing
- `python3 -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688be732840c83298b895aedb7bbe941