### PR TITLE
Add CI workflow and remote usage example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Verify Python syntax
+        run: python -m py_compile scripts/*.py
+      - name: actionlint
+        uses: rhysd/actionlint@v1
+

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ jobs:
 
 This workflow triggers manually through the GitHub UI. When run, it computes coding hours across the specified repositories, writes JSON reports to the `metrics` branch, and publishes the KPI website to the `gh-pages` branch.
 
+### Using in other repositories
+
+To run the action from another repository, reference it by its owner, repository name, and a tag:
+
+```yaml
+- name: Run Org Coding Hours Action
+  uses: other-org/org-coding-hours-action@v1
+  with:
+    repos: owner1/repo1 owner2/repo2
+```
+
+Replace `other-org` with the organization that hosts this action.
+## Continuous Integration
+
+The repository includes a workflow at `.github/workflows/ci.yml` that compiles the Python helper scripts and runs [actionlint](https://github.com/rhysd/actionlint) on every push and pull request.
+
 ## Notes
 
 * The action installs a specific version of `git‑hours` (v0.1.2) using Go 1.24 and executes a Python helper script. If you want to update the version, modify the clone command in `action.yml` accordingly.
@@ -57,3 +73,4 @@ This workflow triggers manually through the GitHub UI. When run, it computes cod
 ## Development and Release
 
 A workflow at `.github/workflows/release.yml` compiles the Python helper scripts on each push and pull request. When a GitHub release is created, the same workflow uploads the action files as assets so they can be downloaded with the release.
+The CI workflow at `.github/workflows/ci.yml` runs the same checks on every push and pull request.


### PR DESCRIPTION
## Summary
- add a CI workflow that checks python syntax and runs actionlint
- document how to call this action from other repositories
- mention the new CI workflow in the README

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688be25e5ab883299f5e3ebd60f8f796