### PR TITLE
Pin actionlint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Verify Python syntax

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Verify Python syntax
         run: python -m py_compile scripts/*.py
       - name: actionlint
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.7
 

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
       shell: bash
     # Setup Python for running our helper scripts. The default Python version available on the runner is sufficient.
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     # Run the org coding hours script which clones each repository, runs git-hours, aggregates results,


### PR DESCRIPTION
## Summary
- fix lint workflow by pinning actionlint version

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bf8a0da48832981b5bbfaa6f004a4