### PR TITLE
Fix release workflow token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- update the release workflow so GITHUB_TOKEN has write permissions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bfda7a8288329811533e031feee4b