### PR TITLE
Fix workflow to collect reports

### DIFF
--- a/.github/workflows/org-coding-hours.yml
+++ b/.github/workflows/org-coding-hours.yml
@@ -25,6 +25,8 @@ permissions:
 
 env:
   GO_VERSION: '1.24'
+  METRICS_BRANCH: metrics
+  PAGES_BRANCH: gh-pages
   REPORTS_DIR: collected-reports
   SITE_DIR: site
 
@@ -75,6 +77,14 @@ jobs:
         with:
           repos: ${{ matrix.repo }}
           window_start: ${{ github.event.inputs.window_start }}
+          metrics_branch: ${{ env.METRICS_BRANCH }}
+          pages_branch: ${{ env.PAGES_BRANCH }}
+
+      - name: Restore reports directory
+        shell: bash
+        run: |
+          git fetch --quiet origin "$METRICS_BRANCH" || exit 0
+          git switch --quiet "$METRICS_BRANCH"
 
       - name: Collect JSON reports
         shell: bash


### PR DESCRIPTION
## Summary
- restore the metrics reports after running the action so the workflow can find them
- parameterize metrics/pages branch names so we can reuse them

## Testing
- `python -m py_compile scripts/*.py`
- `./actionlint -color -verbose` *(passed earlier)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d317127fc832985a288551a2210e0