### PR TITLE
Fix JSON search path

### DIFF
--- a/.github/workflows/org-coding-hours.yml
+++ b/.github/workflows/org-coding-hours.yml
@@ -141,7 +141,7 @@ jobs:
           # Collate per‑repo JSON into a single organisation‑wide aggregate
           # ------------------------------------------------------------------
           org = collections.defaultdict(lambda: {'hours': 0, 'commits': 0})
-          for src in glob.glob("tmp/*.json"):
+          for src in glob.glob("tmp/**/*.json", recursive=True):
               dest = f"{site_dir}/data/{pathlib.Path(src).name}"
               os.system(f"cp {src} {dest}")  # retain raw files
               data = json.load(open(src))


### PR DESCRIPTION
## Summary
- search for downloaded JSON files recursively when building KPI site

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d3b4573008329ac4c9eae3e387507