### PR TITLE
Fix artifact retrieval in test workflow

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -26,11 +26,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: '18' }
+      - uses: actions/download-artifact@v4
+        with: { name: git-hours, path: tmp }
       - run: npm ci --prefix kpi-microsite
       - run: |
           mkdir -p kpi-microsite/src/data
-          cp "${{ needs.test-git-hours.outputs.results }}" \
-             kpi-microsite/src/data/git-hours.json
+          cp tmp/git-hours.json kpi-microsite/src/data/git-hours.json
       - run: npm run build --prefix kpi-microsite
       - uses: actions/upload-artifact@v4
         with: { name: kpi-microsite, path: kpi-microsite/dist }


### PR DESCRIPTION
## Summary
- handle git-hours artifact correctly by downloading it before building the microsite

## Testing
- `pytest -q`
- `actionlint .github/workflows/test-and-release.yml`

------
https://chatgpt.com/codex/tasks/task_e_688d5591d0988329a290c87543717579