### PR TITLE
fix: ensure Python 3.8 compatibility

### DIFF
--- a/scripts/org_coding_hours.py
+++ b/scripts/org_coding_hours.py
@@ -21,6 +21,7 @@ import subprocess
 import tempfile
 import datetime
 import sys
+from typing import Dict, List
 
 # Parse environment variables. Split the REPOS string into individual entries.
 REPOS = os.getenv("REPOS", "").split()
@@ -51,9 +52,9 @@ def run_git_hours(repo: str) -> dict:
         out = subprocess.check_output(cmd, cwd=temp, text=True)
         return json.loads(out)
 
-def aggregate(results: list[dict]) -> dict:
+def aggregate(results: List[dict]) -> Dict[str, dict]:
     """Aggregate per-contributor results across multiple repositories."""
-    agg = {"total": {"hours": 0, "commits": 0}}
+    agg: Dict[str, dict] = {"total": {"hours": 0, "commits": 0}}
     for data in results:
         for email, rec in data.items():
             if email == "total":


### PR DESCRIPTION
## Summary
- expand aggregate typing to use `typing` generics for Python 3.8 support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d66e8da848329a0bd89454e24326a