### PR TITLE
Fix build_site UTC timestamp for older Python versions

### DIFF
--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -35,8 +35,11 @@ def build_site(agg_path: pathlib.Path):
         f"<tr><td>{l}</td><td>{data[l]['hours']}</td><td>{data[l]['commits']}</td></tr>"
         for l in labels
     )
-    # Current UTC timestamp.
-    updated = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M UTC")
+    # Current UTC timestamp. Use datetime.timezone.utc for compatibility with
+    # Python versions prior to 3.11 where datetime.UTC is unavailable.
+    updated = datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%d %H:%M UTC"
+    )
     # Compose the page HTML. Use Simple.css and Chart.js via CDN for styling and charts.
     template = Template(textwrap.dedent("""
     <!doctype html><html lang='en'><head>


### PR DESCRIPTION
## Summary
- use `datetime.timezone.utc` instead of Python 3.11-only `datetime.UTC`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d66e8da848329a0bd89454e24326a