### PR TITLE
fix: resolve git-hours asset dynamically

### DIFF
--- a/.github/actions/git-hours/action.yml
+++ b/.github/actions/git-hours/action.yml
@@ -39,14 +39,26 @@ runs:
       run: |
         set -euo pipefail
         GH_REPO="lazypic/git-hours"
-        OS=$(uname -s)
+
+        # Normalise the platform strings to match release asset names.
+        OS=$(uname -s | tr '[:upper:]' '[:lower:]')
         ARCH=$(uname -m)
-        case "${OS}-${ARCH}" in
-          Linux-x86_64)  ASSET="git-hours_${TAG#v}_Linux_x86_64.tar.gz" ;;
-          Darwin-arm64)  ASSET="git-hours_${TAG#v}_Darwin_arm64.tar.gz" ;;
-          Darwin-x86_64) ASSET="git-hours_${TAG#v}_Darwin_x86_64.tar.gz" ;;
+        case "${ARCH}" in
+          x86_64) ARCH="x86-64" ;;
+          arm64|aarch64) ARCH="arm64" ;;
           *) echo "Unsupported runner platform ${OS}-${ARCH}" && exit 1 ;;
         esac
+
+        # Query the release API for an asset matching the current OS/arch.
+        ASSET=$(curl -sfL "https://api.github.com/repos/${GH_REPO}/releases/tags/${TAG}" \
+          | jq -r '.assets[].name' \
+          | grep "${OS}" | grep "${ARCH}" | head -n1)
+
+        if [ -z "$ASSET" ]; then
+          echo "Unsupported runner platform ${OS}-${ARCH}" >&2
+          exit 1
+        fi
+
         curl -sfL "https://github.com/${GH_REPO}/releases/download/${TAG}/${ASSET}" -o "$ASSET"
         tar -xzf "$ASSET" git-hours
         chmod +x git-hours

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ cd org-coding-hours-action
 npm exec -y @redhat-plumbers-in-action/action-validator .
 
 # Manual git-hours run against this repo
-curl -sL https://github.com/lazypic/git-hours/releases/download/v0.0.6/git-hours_0.0.6_Linux_x86_64.tar.gz  | tar xz git-hours && ./git-hours -format json -output tmp.json .
+curl -sL https://github.com/lazypic/git-hours/releases/download/v0.0.6/git-hours_linux_x86-64.tgz \
+  | tar xz git-hours && ./git-hours -format json -output tmp.json .
 ```
 
 ---


### PR DESCRIPTION
## Summary
- resolve git-hours asset dynamically based on current OS/arch
- update manual download instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d68ffdb4c832981d0c4387a09a6ed