### PR TITLE
refactor: pin git-hours v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ It serves three parallel goals:
 
 | Feature | Description |
 |---------|-------------|
-| **Per‑repo & org‑wide metrics** | Uses the upstream [`git‑hours`](https://github.com/lazypic/git-hours) binary to calculate coding‑hour totals per author, per repository. |
-| **Go-based install** | The action builds the `git‑hours` CLI via `go install`; the runner must have the Go tool‑chain available. |
+| **Per‑repo & org‑wide metrics** | Uses the upstream [`git‑hours`](https://github.com/Kimmobrunfeldt/git-hours) binary to calculate coding‑hour totals per author, per repository. |
+| **Go-based install** | The action builds the `git‑hours` CLI via `go install` (`Kimmobrunfeldt/git-hours@v1.5.0`); the runner must have the Go tool‑chain available. |
 | **Dashboard optional** | JSON reports are always produced; an *optional* Hugo‑based site can be built & deployed to GitHub Pages for KPI visualisation. |
 | **Runs anywhere** | Works on public and private repos (needs a token for private). Linux/macOS runners supported out‑of‑the‑box. |
 
@@ -123,7 +123,7 @@ cd org-coding-hours-action
 npm exec -y @redhat-plumbers-in-action/action-validator .
 
 # Manual git-hours run against this repo
-go install github.com/lazypic/git-hours@latest
+go install github.com/Kimmobrunfeldt/git-hours@v1.5.0
 $(go env GOPATH)/bin/git-hours -format json -output tmp.json .
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,6 @@ inputs:
     description: Branch to which the generated KPI site will be committed (for GitHub Pages).
     default: gh-pages
     required: false
-  git_hours_version:
-    description: git-hours release tag to install (e.g. v0.0.6) or "latest"
-    default: latest
-    required: false
 outputs:
   aggregated_report:
     description: Path to the aggregated JSON report file
@@ -42,11 +38,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        VERSION="${{ inputs.git_hours_version }}"
-        if [ "$VERSION" = "latest" ]; then
-          VERSION="latest"
-        fi
-        GO111MODULE=on go install github.com/lazypic/git-hours@"$VERSION"
+        GO111MODULE=on go install github.com/Kimmobrunfeldt/git-hours@v1.5.0
         echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
     # Setup Python for running our helper scripts. The default Python version available on the runner is sufficient.
     - name: Setup Python


### PR DESCRIPTION
## Summary
- remove configurable git-hours version and install Kimmobrunfeldt/git-hours@v1.5.0
- update README to reference the official git-hours repo and pinned version

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d722065248329b104b27ed5f89c0e