### PR TITLE
Build git-hours from source and pin v1.5.0

### DIFF
--- a/.github/actions/git-hours/action.yml
+++ b/.github/actions/git-hours/action.yml
@@ -1,10 +1,10 @@
 name: 'Run git-hours'
-description: 'Download a pre‑built git-hours binary and output hours‑per‑author JSON'
+description: 'Build git-hours from source and output hours‑per‑author JSON'
 inputs:
   version:
-    description: 'Release tag of Kimmobrunfeldt/git-hours to use (e.g. v1.5.0). Use "latest" for the newest.'
+    description: 'Release tag of Kimmobrunfeldt/git-hours to build from source (e.g. v1.5.0). Use "latest" for the newest.'
     required: false
-    default: latest
+    default: v1.5.0
   workdir:
     description: 'Path to the repository that should be analysed'
     required: false
@@ -14,59 +14,21 @@ runs:
   using: "composite"
   steps:
     # ------------------------------------------------------------------
-    # 1. Resolve the release tag
+    # 1. Setup Go and build git-hours
     # ------------------------------------------------------------------
-    - name: Compute tag
-      id: tag
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.x'
+
+    - name: Install git-hours
       shell: bash
       run: |
-        if [ "${{ inputs.version }}" = "latest" ]; then
-          GH_REPO="Kimmobrunfeldt/git-hours"
-          TAG=$(curl -sfL "https://api.github.com/repos/${GH_REPO}/releases/latest" \
-                | grep -m1 '"tag_name"' | cut -d '"' -f4)
-        else
-          TAG="${{ inputs.version }}"
-          GH_REPO="Kimmobrunfeldt/git-hours"
-        fi
-        echo "repo=$GH_REPO" >> "$GITHUB_OUTPUT"
-        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        go install github.com/Kimmobrunfeldt/git-hours@${{ inputs.version }}
+        echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
     # ------------------------------------------------------------------
-    # 2. Download the matching tarball
-    # ------------------------------------------------------------------
-    - name: Download pre‑built binary
-      shell: bash
-      env:
-        TAG: ${{ steps.tag.outputs.tag }}
-        GH_REPO: ${{ steps.tag.outputs.repo }}
-      run: |
-        set -euo pipefail
-        # Normalise the platform strings to match release asset names.
-        OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-        ARCH=$(uname -m)
-        case "${ARCH}" in
-          x86_64) ARCH="x86-64" ;;
-          arm64|aarch64) ARCH="arm64" ;;
-          *) echo "Unsupported runner platform ${OS}-${ARCH}" && exit 1 ;;
-        esac
-
-        # Query the release API for an asset matching the current OS/arch.
-        ASSET=$(curl -sfL "https://api.github.com/repos/${GH_REPO}/releases/tags/${TAG}" \
-          | jq -r '.assets[].name' \
-          | grep "${OS}" | grep "${ARCH}" | head -n1)
-
-        if [ -z "$ASSET" ]; then
-          echo "Unsupported runner platform ${OS}-${ARCH}" >&2
-          exit 1
-        fi
-
-        curl -sfL "https://github.com/${GH_REPO}/releases/download/${TAG}/${ASSET}" -o "$ASSET"
-        tar -xzf "$ASSET" git-hours
-        chmod +x git-hours
-        echo "${PWD}" >> $GITHUB_PATH   # <- expose git-hours to later steps
-
-    # ------------------------------------------------------------------
-    # 3. Generate coding‑hours report
+    # 2. Generate coding‑hours report
     # ------------------------------------------------------------------
     - name: Run git-hours
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: ./.github/actions/git-hours
         id: gh
         with:
-          version: latest              # or pin, e.g. v0.0.6
+          version: v1.5.0              # pinned source build
 
       # 3. Upload the JSON with a *versioned* name
       - uses: actions/upload-artifact@v4.3.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: ./.github/actions/git-hours
         with:
-          version: latest
+          version: v1.5.0              # pinned source build
 
       - uses: actions/upload-artifact@v4.3.1
         with:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It serves three parallel goals:
 | Feature | Description |
 |---------|-------------|
 | **Per‑repo & org‑wide metrics** | Uses the upstream [`git‑hours`](https://github.com/Kimmobrunfeldt/git-hours) binary to calculate coding‑hour totals per author, per repository. |
-| **Pre-built binary** | Downloads the `git‑hours` CLI (e.g. `Kimmobrunfeldt/git-hours@v1.5.0`); no Go tool‑chain required. |
+| **Builds from source** | Compiles `Kimmobrunfeldt/git-hours@v1.5.0` on the runner; Go toolchain required. |
 | **Dashboard optional** | JSON reports are always produced; an *optional* Hugo‑based site can be built & deployed to GitHub Pages for KPI visualisation. |
 | **Runs anywhere** | Works on public and private repos (needs a token for private). Linux/macOS runners supported out‑of‑the‑box. |
 
@@ -75,6 +75,8 @@ jobs:
           name: git-hours-${{ github.run_number }}.json
           path: reports/git-hours-aggregated-*.json
 ```
+
+> **Note:** This action builds `git-hours` from source and requires the Go toolchain. The necessary Go version is installed automatically using `actions/setup-go`.
 
 ### Full “JSON + Dashboard + Pages” (outline)
 

--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,8 @@ runs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    # Download a pre-built git-hours binary and expose it on PATH.
-    - name: Install git-hours
+    # Build git-hours from source and expose it on PATH.
+    - name: Build git-hours
       uses: ./.github/actions/git-hours
       with:
         version: v1.5.0


### PR DESCRIPTION
## Summary
- build Kimmobrunfeldt/git-hours from source using the Go toolchain
- pin CI and release workflows to git-hours v1.5.0
- document Go requirement and source build in README

## Testing
- `pytest`
- `npx @redhat-plumbers-in-action/action-validator .` *(fails: 404 Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_688d7ffd145c8329b0cb2b6c972ccff3