### PR TITLE
Harden workflows and scripts

### DIFF
--- a/.github/actions/git-hours/action.yml
+++ b/.github/actions/git-hours/action.yml
@@ -1,15 +1,34 @@
+name: "git-hours"
+description: "Internal composite action to run git-hours"
+
+inputs:
+  workdir:
+    description: "Path to the repository to analyse"
+    required: false
+    default: "."
+  version:
+    description: "git-hours package version to install (npm tag)"
+    required: false
+    default: "v1.5.0"
+
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
       with:
-        node-version: '14'
+        node-version: '20'
 
     - name: Install git-hours
       shell: bash
       run: |
-        npm install -g git-hours@${{ inputs.version }} \
-        || { npm install -g nodegit && npm install -g git-hours@${{ inputs.version }}; }
+        set -euo pipefail
+        VERSION="${{ inputs.version }}"
+        if [[ ! "$VERSION" =~ ^v?\d+(\.\d+){2}$ ]]; then
+          echo "Invalid git-hours version: $VERSION" >&2
+          exit 1
+        fi
+        npm install -g git-hours@"$VERSION" \
+        || { npm install -g nodegit && npm install -g git-hours@"$VERSION"; }
         echo "$(npm bin -g)" >> "$GITHUB_PATH"
 
     - name: Run git-hours
@@ -17,6 +36,7 @@ runs:
       env:
         WORKDIR: ${{ inputs.workdir }}
       run: |
+        set -euo pipefail
         cd "$WORKDIR"
         # Default CLI output is JSON → capture it
         git-hours > "$GITHUB_WORKSPACE/git-hours.json"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "LabVIEW-Community-CI-CD"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "LabVIEW-Community-CI-CD"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "LabVIEW-Community-CI-CD"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # 1. Checkout full history so git‑hours can traverse every commit
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           fetch-depth: 0
 
@@ -29,7 +29,7 @@ jobs:
           version: v1.5.0              # pinned source build
 
       # 3. Upload the JSON with a *versioned* name
-      - uses: actions/upload-artifact@v4.3.1
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: git-hours-${{ github.run_number }}.json
           path: git-hours.json

--- a/.github/workflows/org-coding-hours.yml
+++ b/.github/workflows/org-coding-hours.yml
@@ -3,9 +3,12 @@ name: Org Coding Hours
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   hours:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: LabVIEW-Community-CI-CD/org-coding-hours-action@v9
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      - uses: LabVIEW-Community-CI-CD/org-coding-hours-action@0fc5e8b705a8855d2ed08e375eaa345034543be2 # v9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production    # human approval gate
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           fetch-depth: 0
 
@@ -29,14 +29,14 @@ jobs:
         with:
           version: v1.5.0              # pinned source build
 
-      - uses: actions/upload-artifact@v4.3.1
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: git-hours-${{ github.run_number }}.json
           path: git-hours.json
 
       # Create / update the GitHub Release and attach the report
       - name: Create draft GitHub Release
-        uses: softprops/action-gh-release@v2.0.5
+        uses: softprops/action-gh-release@4fabdc8bec0ad32a2eb09fb8fd1d04fd30a75562 # v2.0.5
         with:
           draft: true
           files: git-hours.json

--- a/action.yml
+++ b/action.yml
@@ -22,16 +22,22 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
       with:
-        node-version: '14'
+        node-version: '20'
 
     - name: Install git-hours
       shell: bash
       run: |
-        npm install -g git-hours@${{ inputs.version }} || {
+        set -euo pipefail
+        VERSION="${{ inputs.version }}"
+        if [[ ! "$VERSION" =~ ^v?\d+(\.\d+){2}$ ]]; then
+          echo "Invalid git-hours version: $VERSION" >&2
+          exit 1
+        fi
+        npm install -g git-hours@"$VERSION" || {
           echo "Retrying with nodegit pre-install";
-          npm install -g nodegit && npm install -g git-hours@${{ inputs.version }};
+          npm install -g nodegit && npm install -g git-hours@"$VERSION";
         }
         echo "$(npm bin -g)" >> "$GITHUB_PATH"
 
@@ -40,5 +46,6 @@ runs:
       env:
         WORKDIR: ${{ inputs.workdir }}
       run: |
+        set -euo pipefail
         cd "$WORKDIR"
         git-hours > "$GITHUB_WORKSPACE/git-hours.json"

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -46,9 +46,9 @@ def build_site(agg_path: pathlib.Path):
     <!doctype html><html lang='en'><head>
       <meta charset='utf-8'>
       <title>Organization Coding Hours</title>
-      <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/simpledotcss/simple.min.css'>
-      <script src='https://cdn.jsdelivr.net/npm/sortable-tablesort/sortable.min.js' defer></script>
-      <script src='https://cdn.jsdelivr.net/npm/chart.js'></script>
+      <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/simpledotcss@2.3.7/simple.min.css' integrity='sha384-w3/JhK7GP1jIgYT9phdYXYeUKzhTc4AxDpfqFZO1tkmCHBZrEmZ2c68gaD1yKhZq' crossorigin='anonymous'>
+      <script src='https://cdn.jsdelivr.net/npm/sortable-tablesort@4.0.2/dist/sortable.min.js' integrity='sha384-pqkoLYBQc/BySWKYrG2W0Vm875A9ceoM3KviBmvun6omeICxuFsN2nRZ5kf6THU0' crossorigin='anonymous' defer></script>
+      <script src='https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js' integrity='sha384-XcdcwHqIPULERb2yDEM4R0XaQKU3YnDsrTmjACBZyfdVVqjh6xQ4/DCMd7XLcA6Y' crossorigin='anonymous'></script>
       <style>canvas{max-height:400px}</style>
     </head><body><main>
       <h1>Organization Coding Hours</h1>

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -96,11 +96,11 @@ def _run_main_subprocess(monkeypatch, tmp_path, repos):
 
     clone_dir = {}
 
-    def fake_run(cmd, check):
+    def fake_run(cmd, check, timeout=None):
         assert cmd[0] == "git" and cmd[1] == "clone"
         clone_dir["path"] = cmd[-1]
 
-    def fake_check_output(cmd, cwd, text):
+    def fake_check_output(cmd, cwd, text, timeout=None):
         assert cmd[0] == "git-hours"
         assert "-format" in cmd and "json" in cmd
         assert "-output" in cmd and "-" in cmd
@@ -145,10 +145,10 @@ def test_clone_uses_token(monkeypatch, tmp_path):
 
     seen = {}
 
-    def fake_run(cmd, check):
+    def fake_run(cmd, check, timeout=None):
         seen["url"] = cmd[2]
 
-    def fake_check_output(cmd, cwd, text):
+    def fake_check_output(cmd, cwd, text, timeout=None):
         return json.dumps({"total": {"hours": 1, "commits": 1}})
 
     monkeypatch.setattr(oc.subprocess, "run", fake_run)


### PR DESCRIPTION
## Summary
- upgrade composite actions to Node 20 with strict bash options and version validation
- add subprocess timeouts and graceful handling in org_coding_hours.py
- pin GitHub Actions to commit SHAs and configure Dependabot

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688da1f434e083298066cc27f9026067