### PR TITLE
chore: drop site build and pages deployment

### DIFF
--- a/.github/workflows/org-coding-hours.yml
+++ b/.github/workflows/org-coding-hours.yml
@@ -20,15 +20,12 @@ concurrency:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 env:
   GO_VERSION: '1.24'
   METRICS_BRANCH: metrics
   PAGES_BRANCH: gh-pages
   REPORTS_DIR: collected-reports
-  SITE_DIR: site
 
 # ───────────────────────────────────────────────────────────────
 # 0) Convert the repos input into a matrix‑friendly JSON array
@@ -111,122 +108,3 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
-# ───────────────────────────────────────────────────────────────
-# 2) Build the KPI microsite (aggregates all repo artefacts)
-# ───────────────────────────────────────────────────────────────
-  build-site:
-    needs: report
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download all JSON artefacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: git-hours-json-*          # grab every repo
-          merge-multiple: true               # flatten into one dir  :contentReference[oaicite:2]{index=2}
-          path: tmp
-
-      - name: Build KPI microsite
-        shell: bash
-        run: |
-          set -euo pipefail
-          python <<'PY'
-          import json, collections, html, textwrap, datetime as dt, pathlib, os
-          site_dir = os.environ['SITE_DIR']
-          pathlib.Path(f"{site_dir}/data").mkdir(parents=True, exist_ok=True)
-
-          # ------------------------------------------------------------------
-          # Collate per‑repo JSON into a single organisation‑wide aggregate
-          # ------------------------------------------------------------------
-          org = collections.defaultdict(lambda: {'hours': 0, 'commits': 0})
-          # actions/download-artifact places each artifact in its own
-          # subdirectory, so search recursively for the JSON files
-          for src in pathlib.Path("tmp").rglob("*.json"):
-              dest = f"{site_dir}/data/{pathlib.Path(src).name}"
-              os.system(f"cp {src} {dest}")  # retain raw files
-              data = json.load(open(src))
-              for user, stats in data.items():
-                  if user == 'total':
-                      continue
-                  org[user]['hours'] += stats['hours']
-                  org[user]['commits'] += stats['commits']
-
-          total_hours = sum(v['hours'] for v in org.values())
-          total_commits = sum(v['commits'] for v in org.values())
-          org_total = {'hours': total_hours, 'commits': total_commits}
-          org['total'] = org_total
-
-          def rows(d):
-              return "\n".join(
-                  f"<tr><td>{html.escape(u)}</td><td>{s['hours']}</td><td>{s['commits']}</td></tr>"
-                  for u, s in d.items() if u != 'total')
-
-          sections = []
-          for per_repo in glob.glob(f"{site_dir}/data/*.json"):
-              if 'aggregated' in per_repo:  # legacy files, if any
-                  continue
-              repo_key = pathlib.Path(per_repo).stem.replace('_','/')
-              r = json.load(open(per_repo))
-              sections.append(
-                  f"<h2>{html.escape(repo_key)}</h2>"
-                  f"<table class='sortable'><thead><tr><th>Contributor</th>"
-                  f"<th>Hours</th><th>Commits</th></tr></thead><tbody>{rows(r)}</tbody></table>"
-              )
-
-          page = f"""
-          <!doctype html><html lang=en><head><meta charset=utf-8>
-          <meta name=viewport content='width=device-width,initial-scale=1'>
-          <title>Collaborator KPIs</title>
-          <link rel=stylesheet href='https://cdn.jsdelivr.net/npm/simpledotcss@2/simple.min.css'>
-          <script src='https://cdn.jsdelivr.net/npm/sortable-tablesort@1/sortable.min.js' defer></script>
-          <script src='https://cdn.jsdelivr.net/npm/chart.js@4'></script>
-          <style>canvas{{max-height:400px}}</style></head><body><main>
-          <h1>Collaborator KPIs</h1><p><em>Last updated {dt.datetime.utcnow():%Y-%m-%d %H:%M UTC}</em></p>
-          <h2>Totals (all repos)</h2>
-          <ul><li><strong>Hours</strong>: {org_total['hours']}</li>
-          <li><strong>Commits</strong>: {org_total['commits']}</li>
-          <li><strong>Contributors</strong>: {len(org)-1}</li></ul>
-          <h2>Hours per contributor</h2><canvas id=hoursChart></canvas>
-          <h2>Commits per contributor</h2><canvas id=commitsChart></canvas>
-          <h2>Detail table (all repos)</h2>
-          <table class=sortable><thead><tr><th>Contributor</th><th>Hours</th><th>Commits</th></tr></thead>
-          <tbody>{rows(org)}</tbody></table>
-          {''.join(sections)}
-          <p>Historical JSON snapshots live in <code>/data</code>.</p>
-          <script>
-          const fmt = x=>x;
-          const hoursChart=document.getElementById('hoursChart');
-          const commitsChart=document.getElementById('commitsChart');
-          const d = {json.dumps(org)};
-          const labels = Object.keys(d).filter(k=>k!=='total');
-          const H = labels.map(l=>d[l].hours);
-          const C = labels.map(l=>d[l].commits);
-          new Chart(hoursChart,{{type:'bar',data:{{labels,datasets:[{{label:'Hours',data:H}}] }},
-           options:{{responsive:true,maintainAspectRatio:false,plugins:{{legend:{{display:false}}}},scales:{{y:{{beginAtZero:true}}}}}}});
-          new Chart(commitsChart,{{type:'bar',data:{{labels,datasets:[{{label:'Commits',data:C}}] }},
-           options:{{responsive:true,maintainAspectRatio:false,plugins:{{legend:{{display:false}}}},scales:{{y:{{beginAtZero:true}}}}}}});
-          </script></main></body></html>
-          """
-          pathlib.Path(f"{site_dir}/index.html").write_text(textwrap.dedent(page))
-          PY
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ${{ env.SITE_DIR }}
-
-# ───────────────────────────────────────────────────────────────
-# 3) Publish to GitHub Pages (skip on pull‑requests)
-# ───────────────────────────────────────────────────────────────
-  deploy-pages:
-    if: ${{ github.event_name != 'pull_request' }}  # :contentReference[oaicite:3]{index=3}
-    needs: build-site
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- remove site build and GitHub Pages deployment jobs from org-coding-hours workflow
- drop unused permissions and env variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e31e7dc708329a675bda0113cf1dc