### PR TITLE
Add pytest job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,20 @@ jobs:
           name: git-hours-${{ github.run_number }}.json
           path: git-hours.json
 
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: pytest -q
+
   org-coding-hours:
     name: Org Coding Hours (${{ matrix.name }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add Python-based pytest job to CI workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e3af947ac8329bb8ef5e11eb8674a