### PR TITLE
feat: skip redundant checkout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,7 @@ runs:
   steps:
     # Ensure we have the repository checked out so that git operations and script files are available.
     - name: Checkout repository
+      if: ${{ hashFiles('.git/HEAD') == '' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0


### PR DESCRIPTION
## Summary
- skip checkout inside action when repo already present

## Testing
- `pytest -q`
- `GITHUB_ACTION_PATH=$PWD REPOS='' bash -c 'python3 "$GITHUB_ACTION_PATH/scripts/org_coding_hours.py"' || true`


------
https://chatgpt.com/codex/tasks/task_e_688e3c2bcd5c8329a0d999307b287281