### PR TITLE
feat: expose repo slug for artifact names

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ jobs:
           path: reports/                   # <‑‑ NOT a wildcard
 ```
 
+Need a unique artifact per repository? When processing a single repo, give the
+action step an `id` and use the `repo_slug` output (slashes replaced by
+underscores) to build a safe artifact name:
+
+```yaml
+      - uses: LabVIEW-Community-CI-CD/org-coding-hours-action@v6
+        id: hours
+        with:
+          repos: ni/labview-icon-editor
+      - uses: actions/upload-artifact@v4
+        with:
+          name: git-hours-json-${{ steps.hours.outputs.repo_slug }}
+          path: reports/
+```
+
 ### 3.2  Two‑job (JSON → site)
 
 ```yaml
@@ -112,6 +127,13 @@ reports/
 ├─ git-hours-aggregated-YYYY‑MM‑DD.json   # all repos
 ├─ git-hours-<repo>-YYYY‑MM‑DD.json       # one per repo
 ```
+
+The action exposes two outputs that can help downstream steps:
+
+| Name | Description |
+|------|-------------|
+| `aggregated_report` | Path to the JSON report (either aggregated or the single repo file). |
+| `repo_slug` | Repository identifier with `/` replaced by `_`; useful for artifact names when a single repo is processed. |
 
 If `pages_branch` is enabled:
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ outputs:
   aggregated_report:
     description: Path to the aggregated JSON report file
     value: ${{ steps.compute.outputs.aggregated_report }}
+  repo_slug:
+    description: Repository identifier safe for artifact names (only set for single repo runs)
+    value: ${{ steps.compute.outputs.repo_slug }}
 
 
 runs:

--- a/scripts/org_coding_hours.py
+++ b/scripts/org_coding_hours.py
@@ -88,9 +88,10 @@ def main():
     # Choose which path to expose as the aggregated_report output. When only
     # a single repository is processed, point at that repo's report so callers
     # don't need to handle aggregation separately.
+    repo_slug = None
     if len(REPOS) == 1:
-        repo_name = REPOS[0].replace('/', '_')
-        output_path = reports / f"git-hours-{repo_name}-{date}.json"
+        repo_slug = REPOS[0].replace('/', '_')
+        output_path = reports / f"git-hours-{repo_slug}-{date}.json"
     else:
         output_path = agg_path
 
@@ -99,6 +100,8 @@ def main():
     if github_output:
         with open(github_output, "a") as fh:
             print(f"aggregated_report={output_path}", file=fh)
+            if repo_slug:
+                print(f"repo_slug={repo_slug}", file=fh)
 
     # Output aggregated JSON to console for reference.
     print(json.dumps(agg, indent=2))

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -70,19 +70,22 @@ def _run_main(monkeypatch, tmp_path, repos):
     monkeypatch.setattr(oc.datetime, "date", FixedDate)
 
     oc.main()
-    return output_file.read_text().strip()
+    lines = output_file.read_text().splitlines()
+    return dict(line.split('=', 1) for line in lines)
 
 
 def test_output_path_single_repo(tmp_path, monkeypatch):
-    line = _run_main(monkeypatch, tmp_path, ["owner/repo"])
+    out = _run_main(monkeypatch, tmp_path, ["owner/repo"])
     expected = "reports/git-hours-owner_repo-2024-01-01.json"
-    assert line == f"aggregated_report={expected}"
+    assert out["aggregated_report"] == expected
+    assert out["repo_slug"] == "owner_repo"
 
 
 def test_output_path_multiple_repos(tmp_path, monkeypatch):
-    line = _run_main(monkeypatch, tmp_path, ["foo/bar", "baz/qux"])
+    out = _run_main(monkeypatch, tmp_path, ["foo/bar", "baz/qux"])
     expected = "reports/git-hours-aggregated-2024-01-01.json"
-    assert line == f"aggregated_report={expected}"
+    assert out["aggregated_report"] == expected
+    assert "repo_slug" not in out
 
 
 def _run_main_subprocess(monkeypatch, tmp_path, repos):
@@ -117,19 +120,22 @@ def _run_main_subprocess(monkeypatch, tmp_path, repos):
     monkeypatch.setattr(oc.datetime, "date", FixedDate)
 
     oc.main()
-    return output_file.read_text().strip()
+    lines = output_file.read_text().splitlines()
+    return dict(line.split('=', 1) for line in lines)
 
 
 def test_main_single_repo(monkeypatch, tmp_path):
-    line = _run_main_subprocess(monkeypatch, tmp_path, ["owner/repo"])
+    out = _run_main_subprocess(monkeypatch, tmp_path, ["owner/repo"])
     expected = "reports/git-hours-owner_repo-2024-01-01.json"
-    assert line == f"aggregated_report={expected}"
+    assert out["aggregated_report"] == expected
+    assert out["repo_slug"] == "owner_repo"
 
 
 def test_main_multiple_repos(monkeypatch, tmp_path):
-    line = _run_main_subprocess(monkeypatch, tmp_path, ["foo/bar", "baz/qux"])
+    out = _run_main_subprocess(monkeypatch, tmp_path, ["foo/bar", "baz/qux"])
     expected = "reports/git-hours-aggregated-2024-01-01.json"
-    assert line == f"aggregated_report={expected}"
+    assert out["aggregated_report"] == expected
+    assert "repo_slug" not in out
 
 
 def test_clone_uses_token(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add `repo_slug` output for safe artifact names
- document repo slug usage and outputs in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e3e35db9c832994a17cd691913bc1