### PR TITLE
feat: sanitize repo slug for artifact names

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ jobs:
           path: reports/                   # <‑‑ NOT a wildcard
 ```
 
-Need a unique artifact per repository? When processing a single repo, give the
-action step an `id` and use the `repo_slug` output (slashes replaced by
-underscores) to build a safe artifact name:
+Need a unique artifact name? Give the action step an `id` and use the
+`repo_slug` output (slashes/whitespace replaced by underscores) to build a
+safe artifact name:
 
 ```yaml
       - uses: LabVIEW-Community-CI-CD/org-coding-hours-action@v6
@@ -133,7 +133,7 @@ The action exposes two outputs that can help downstream steps:
 | Name | Description |
 |------|-------------|
 | `aggregated_report` | Path to the JSON report (either aggregated or the single repo file). |
-| `repo_slug` | Repository identifier with `/` replaced by `_`; useful for artifact names when a single repo is processed. |
+| `repo_slug` | `repos` input sanitized for artifact names (slashes & spaces → `_`). |
 
 If `pages_branch` is enabled:
 

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ outputs:
     description: Path to the aggregated JSON report file
     value: ${{ steps.compute.outputs.aggregated_report }}
   repo_slug:
-    description: Repository identifier safe for artifact names (only set for single repo runs)
+    description: Repositories identifier safe for artifact names (slashes and spaces replaced by underscores)
     value: ${{ steps.compute.outputs.repo_slug }}
 
 

--- a/scripts/org_coding_hours.py
+++ b/scripts/org_coding_hours.py
@@ -21,6 +21,7 @@ import subprocess
 import tempfile
 import datetime
 import sys
+import re
 
 # Parse environment variables. Split the REPOS string into individual entries.
 REPOS = os.getenv("REPOS", "").split()
@@ -51,6 +52,12 @@ def run_git_hours(repo: str) -> dict:
         out = subprocess.check_output(cmd, cwd=temp, text=True)
         return json.loads(out)
 
+
+def slugify(text: str) -> str:
+    """Return a string safe for artifact names."""
+    text = text.replace("/", "_")
+    return re.sub(r"[^0-9A-Za-z._-]+", "_", text)
+
 def aggregate(results: list[dict]) -> dict:
     """Aggregate per-contributor results across multiple repositories."""
     agg = {"total": {"hours": 0, "commits": 0}}
@@ -79,7 +86,7 @@ def main():
     reports.mkdir(exist_ok=True)
     # Write per-repository reports.
     for repo, data in results.items():
-        name = repo.replace('/', '_')
+        name = slugify(repo)
         (reports / f"git-hours-{name}-{date}.json").write_text(json.dumps(data, indent=2))
     # Write aggregated report.
     agg_path = reports / f"git-hours-aggregated-{date}.json"
@@ -88,9 +95,9 @@ def main():
     # Choose which path to expose as the aggregated_report output. When only
     # a single repository is processed, point at that repo's report so callers
     # don't need to handle aggregation separately.
-    repo_slug = None
+    repo_slugs = [slugify(r) for r in REPOS]
+    repo_slug = "-".join(repo_slugs)
     if len(REPOS) == 1:
-        repo_slug = REPOS[0].replace('/', '_')
         output_path = reports / f"git-hours-{repo_slug}-{date}.json"
     else:
         output_path = agg_path
@@ -100,8 +107,7 @@ def main():
     if github_output:
         with open(github_output, "a") as fh:
             print(f"aggregated_report={output_path}", file=fh)
-            if repo_slug:
-                print(f"repo_slug={repo_slug}", file=fh)
+            print(f"repo_slug={repo_slug}", file=fh)
 
     # Output aggregated JSON to console for reference.
     print(json.dumps(agg, indent=2))

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -85,7 +85,7 @@ def test_output_path_multiple_repos(tmp_path, monkeypatch):
     out = _run_main(monkeypatch, tmp_path, ["foo/bar", "baz/qux"])
     expected = "reports/git-hours-aggregated-2024-01-01.json"
     assert out["aggregated_report"] == expected
-    assert "repo_slug" not in out
+    assert out["repo_slug"] == "foo_bar-baz_qux"
 
 
 def _run_main_subprocess(monkeypatch, tmp_path, repos):
@@ -135,7 +135,7 @@ def test_main_multiple_repos(monkeypatch, tmp_path):
     out = _run_main_subprocess(monkeypatch, tmp_path, ["foo/bar", "baz/qux"])
     expected = "reports/git-hours-aggregated-2024-01-01.json"
     assert out["aggregated_report"] == expected
-    assert "repo_slug" not in out
+    assert out["repo_slug"] == "foo_bar-baz_qux"
 
 
 def test_clone_uses_token(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- sanitize repository identifiers so upload-artifact names no longer include `/`
- document `repo_slug` output and sanitized naming rules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e4268215c83298dd89a3527093cfc