### PR TITLE
Fix artifact name sanitization in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
           fi
           cp "${reports[@]}" "${REPORTS_DIR}/"
       - id: sanitize
+        shell: bash
         run: |
           safe=${REPO//[\\/ ]/-}
           echo "repo=${safe}" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- ensure org-coding-hours workflow sanitizes repo names using bash parameter expansion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e47298b0c832989e86857dfe013a2