### PR TITLE
feat: add python-based Dockerfile for container action

### DIFF
--- a/docker-action/Dockerfile
+++ b/docker-action/Dockerfile
@@ -1,31 +1,25 @@
-FROM ubuntu:22.04
+FROM golang:1.24-bullseye AS builder
 
-# Install required packages
+# Build the git-hours binary
+ARG GIT_HOURS_VERSION=v0.1.2
+RUN git clone --depth 1 --branch ${GIT_HOURS_VERSION} https://github.com/trinhminhtriet/git-hours.git /src/git-hours \
+    && sed -i 's/go 1.24.1/go 1.24/' /src/git-hours/go.mod \
+    && cd /src/git-hours && go install .
+
+FROM python:3.11-slim
+
+# Install system packages required for cloning repositories
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
-    curl \
-    python3 \
-    wget \
     ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-# Install Go 1.24
-RUN wget -q https://go.dev/dl/go1.24.linux-amd64.tar.gz -O /tmp/go.tgz \ 
-  && tar -C /usr/local -xzf /tmp/go.tgz \ 
-  && rm /tmp/go.tgz
-ENV PATH="/usr/local/go/bin:${PATH}"
+# Add git-hours to PATH
+COPY --from=builder /go/bin/git-hours /usr/local/bin/git-hours
+ENV PATH="/usr/local/bin:${PATH}"
 
-# Install git-hours
-ARG INPUT_GIT_HOURS_VERSION=v0.1.2
-ENV GIT_HOURS_VERSION=${INPUT_GIT_HOURS_VERSION}
-RUN git clone --depth 1 --branch ${GIT_HOURS_VERSION} https://github.com/trinhminhtriet/git-hours.git /tmp/git-hours \ 
-  && sed -i 's/go 1.24.1/go 1.24/' /tmp/git-hours/go.mod \ 
-  && cd /tmp/git-hours && go install . \ 
-  && rm -rf /tmp/git-hours
+# Copy action scripts
+COPY scripts/org_coding_hours.py /action/org_coding_hours.py
 
-# Copy scripts and entrypoint
-COPY scripts/ /scripts/
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["python3", "/action/org_coding_hours.py"]
 
-ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- build git-hours in a Go builder stage and run on python:3.11-slim
- install git and ca-certificates, copy action script, and set Python entrypoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec494e1748329807f8254298a0150