### PR TITLE
Install git in builder stage

### DIFF
--- a/docker-action/Dockerfile
+++ b/docker-action/Dockerfile
@@ -4,8 +4,10 @@ FROM golang:1.24-bullseye AS builder
 # If building behind a corporate proxy with a custom certificate,
 # copy it into /usr/local/share/ca-certificates/ before the
 # `update-ca-certificates` step.
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git \
+  && rm -rf /var/lib/apt/lists/*
 # COPY corporate.crt /usr/local/share/ca-certificates/corporate.crt
 RUN update-ca-certificates
 


### PR DESCRIPTION
## Summary
- ensure builder stage installs git so git clone works during image build

## Testing
- `pytest -q`
- `REGISTRIES_CONFIG_PATH=/tmp/registries.conf podman build -t org-coding-hours-action docker-action` *(fails: operation not permitted mounting proc)*

------
https://chatgpt.com/codex/tasks/task_e_688ed01c30d083299ad112fbdba705cb