### PR TITLE
Build CLI before running Pester tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         shell: pwsh
         run: |
           Install-Module -Name Pester -Scope CurrentUser -Force -SkipPublisherCheck:contentReference[oaicite:3]{index=3}
+      - name: Build CLI
+        run: dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --configuration Release
       - name: Run Pester tests
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- build OrgCodingHoursCLI before executing Pester tests

## Testing
- `dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --configuration Release`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: RuntimeException: The expression after '&'...)*

------
https://chatgpt.com/codex/tasks/task_e_688f7b62929c832990a291bdfca40df6