### PR TITLE
ci: fix Pester install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Pester (latest)
         shell: pwsh
         run: |
-          Install-Module -Name Pester -Scope CurrentUser -Force -SkipPublisherCheck:contentReference[oaicite:3]{index=3}
+          Install-Module -Name Pester -Scope CurrentUser -Force -SkipPublisherCheck
       - name: Build CLI
         run: dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --configuration Release
       - name: Run Pester tests


### PR DESCRIPTION
## Summary
- ensure CI installs latest Pester module using `Install-Module` with `-SkipPublisherCheck`

## Testing
- `dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --configuration Release`
- `pwsh -NoLogo -NoProfile -Command "Install-Module -Name Pester -Scope CurrentUser -Force -SkipPublisherCheck; Invoke-Pester"` *(fails: The expression after '&' in a pipeline element produced an object that was not valid)*

------
https://chatgpt.com/codex/tasks/task_e_688f7ef9934c8329beab2f5a203e700e