### PR TITLE
Specify Pester version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Pester (latest)
         shell: pwsh
         run: |
-          Install-Module -Name Pester -Scope CurrentUser -Force -SkipPublisherCheck:contentReference[oaicite:3]{index=3}
+          Install-Module -Name Pester -RequiredVersion 5.5.0 -Scope CurrentUser -Force
       - name: Build CLI
         run: dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --configuration Release
       - name: Run Pester tests


### PR DESCRIPTION
## Summary
- pin Pester module to a specific version and drop publisher check in CI

## Testing
- `dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --configuration Release`
- `Invoke-Pester` *(fails: The expression after '&' in a pipeline element produced an object that was not valid)*

------
https://chatgpt.com/codex/tasks/task_e_688f80bf83b48329bd52cfb97f5d58b2