### PR TITLE
Remove stray contentReference fragments from tests

### DIFF
--- a/tests/OrgCodingHoursCLI.Tests.ps1
+++ b/tests/OrgCodingHoursCLI.Tests.ps1
@@ -46,7 +46,7 @@ Describe "OrgCodingHoursCLI" {
 
             # Load and inspect the aggregated JSON content
             $aggReport = Get-Content -Raw -Path $aggReportFiles[0].FullName | ConvertFrom-Json
-            # The aggregated JSON should have a 'total' object and per-contributor entries:contentReference[oaicite:1]{index=1}
+            # The aggregated JSON should have a 'total' object and per-contributor entries
             ($aggReport.PSObject.Properties.Name -contains 'total') | Should -Be $true
             $aggReport.total.hours   | Should -Not -Be $null
             $aggReport.total.commits | Should -Not -Be $null
@@ -92,7 +92,7 @@ Describe "OrgCodingHoursCLI" {
             $slugLine -match '^repo_slug=(.+)$' | Out-Null
             $outputSlug = $Matches[1]
 
-            # The repo_slug output should be a slugified identifier of the repo list:contentReference[oaicite:2]{index=2}
+            # The repo_slug output should be a slugified identifier of the repo list
             $outputSlug | Should -Be 'octocat_Hello-World'   # expected slug for "octocat/Hello-World"
             # The aggregated_report output should point to an existing JSON file in the workspace
             Test-Path $outputPath | Should -Be $true


### PR DESCRIPTION
## Summary
- remove leftover contentReference markers in OrgCodingHoursCLI tests

## Testing
- `pwsh -v` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_688f842910888329b9daceb9d250d10b