### PR TITLE
refactor tests to use local repo

### DIFF
--- a/tests/OrgCodingHoursCLI.Error.Tests.ps1
+++ b/tests/OrgCodingHoursCLI.Error.Tests.ps1
@@ -1,12 +1,14 @@
 # Resolve the path to the OrgCodingHoursCLI executable (same logic as in other test file)
-$repoRoot   = Split-Path -Path $PSScriptRoot -Parent
-$cliExePath = Join-Path $repoRoot "OrgCodingHoursCLI/bin/Release/net7.0/OrgCodingHoursCLI"
-if (-not (Test-Path $cliExePath)) {
-    $cliExePath = Join-Path $repoRoot "OrgCodingHoursCLI/bin/Debug/net7.0/OrgCodingHoursCLI"
-}
-if ($IsWindows) { $cliExePath += ".exe" }
-
 Describe "OrgCodingHoursCLI Error Handling" {
+
+    BeforeAll {
+        $repoRoot = Split-Path -Path $PSScriptRoot -Parent
+        $script:cliExePath = Join-Path $repoRoot "OrgCodingHoursCLI/bin/Release/net7.0/OrgCodingHoursCLI"
+        if (-not (Test-Path $script:cliExePath)) {
+            $script:cliExePath = Join-Path $repoRoot "OrgCodingHoursCLI/bin/Debug/net7.0/OrgCodingHoursCLI"
+        }
+        if ($IsWindows) { $script:cliExePath += ".exe" }
+    }
 
     BeforeEach {
         # Ensure no required env vars are set and no leftover output
@@ -26,7 +28,7 @@ Describe "OrgCodingHoursCLI Error Handling" {
         Remove-Item Env:REPOS -ErrorAction SilentlyContinue
 
         # Act: Run the CLI without the required REPOS input, capturing any error output
-        $result = & $cliExePath 2>&1
+        $result = & $script:cliExePath 2>&1
         $exitCode = $LASTEXITCODE
 
         # Assert: The CLI should exit with an error (non-zero exit code)


### PR DESCRIPTION
## Summary
- run tests against a temporary git fixture instead of `octocat/Hello-World`
- stub `git-hours` for deterministic output in tests
- ensure CLI path resolved inside test setup

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests"`

------
https://chatgpt.com/codex/tasks/task_e_688f856801bc8329808781466f04102d