### PR TITLE
chore: target net8 for CLI

### DIFF
--- a/OrgCodingHoursCLI/OrgCodingHoursCLI.csproj
+++ b/OrgCodingHoursCLI/OrgCodingHoursCLI.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <!-- No additional dependencies; using built-in libraries -->
   </PropertyGroup>
 </Project>
+

--- a/tests/OrgCodingHoursCLI.Error.Tests.ps1
+++ b/tests/OrgCodingHoursCLI.Error.Tests.ps1
@@ -1,10 +1,26 @@
 # Resolve the path to the OrgCodingHoursCLI executable (same logic as in other test file)
-$repoRoot   = Split-Path -Path $PSScriptRoot -Parent
-$cliExePath = Join-Path $repoRoot "OrgCodingHoursCLI/bin/Release/net7.0/OrgCodingHoursCLI"
-if (-not (Test-Path $cliExePath)) {
-    $cliExePath = Join-Path $repoRoot "OrgCodingHoursCLI/bin/Debug/net7.0/OrgCodingHoursCLI"
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent
+
+$candidatePaths = @(
+    "OrgCodingHoursCLI/bin/Release/net8.0/OrgCodingHoursCLI",
+    "OrgCodingHoursCLI/bin/Debug/net8.0/OrgCodingHoursCLI",
+    "OrgCodingHoursCLI/bin/Release/net7.0/OrgCodingHoursCLI",
+    "OrgCodingHoursCLI/bin/Debug/net7.0/OrgCodingHoursCLI"
+)
+
+foreach ($relativePath in $candidatePaths) {
+    $possible = Join-Path $repoRoot $relativePath
+    if (Test-Path $possible) {
+        Set-Variable -Name cliExePath -Value $possible -Scope Script
+        break
+    }
 }
-if ($IsWindows) { $cliExePath += ".exe" }
+
+if (-not $script:cliExePath) {
+    throw "Unable to locate OrgCodingHoursCLI executable. Please build the project."
+}
+
+if ($IsWindows) { $script:cliExePath += ".exe" }
 
 Describe "OrgCodingHoursCLI Error Handling" {
 

--- a/tests/OrgCodingHoursCLI.Tests.ps1
+++ b/tests/OrgCodingHoursCLI.Tests.ps1
@@ -1,10 +1,27 @@
 # Resolve the path to the OrgCodingHoursCLI executable (assumes the project is built)
-$repoRoot   = Split-Path -Path $PSScriptRoot -Parent
-$cliExePath = Join-Path $repoRoot "OrgCodingHoursCLI/bin/Release/net7.0/OrgCodingHoursCLI"
-if (-not (Test-Path $cliExePath)) {
-    $cliExePath = Join-Path $repoRoot "OrgCodingHoursCLI/bin/Debug/net7.0/OrgCodingHoursCLI"
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent
+
+# Prefer net8.0 builds but fall back to net7.0 if present
+$candidatePaths = @(
+    "OrgCodingHoursCLI/bin/Release/net8.0/OrgCodingHoursCLI",
+    "OrgCodingHoursCLI/bin/Debug/net8.0/OrgCodingHoursCLI",
+    "OrgCodingHoursCLI/bin/Release/net7.0/OrgCodingHoursCLI",
+    "OrgCodingHoursCLI/bin/Debug/net7.0/OrgCodingHoursCLI"
+)
+
+foreach ($relativePath in $candidatePaths) {
+    $possible = Join-Path $repoRoot $relativePath
+    if (Test-Path $possible) {
+        Set-Variable -Name cliExePath -Value $possible -Scope Script
+        break
+    }
 }
-if ($IsWindows) { $cliExePath += ".exe" }
+
+if (-not $script:cliExePath) {
+    throw "Unable to locate OrgCodingHoursCLI executable. Please build the project."
+}
+
+if ($IsWindows) { $script:cliExePath += ".exe" }
 
 Describe "OrgCodingHoursCLI" {
 


### PR DESCRIPTION
## Summary
- upgrade CLI project to .NET 8
- allow tests to locate net8.0 build (fallback to net7.0)

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests"`


------
https://chatgpt.com/codex/tasks/task_e_688f8ad432cc83299b988f21189aca2d