### PR TITLE
refactor: use go git-hours binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-**Org Coding Hours** is a GitHub Action that aggregates **per-contributor coding hours** across one or more repositories. It uses the [`git-hours`](https://github.com/kimmobrunfeldt/git-hours) utility to estimate how many hours each contributor has spent (based on commit timestamps), and produces JSON summary reports. Optionally, it can also generate a **static HTML dashboard** and publish both the JSON metrics and the site to dedicated branches (for example, to host on GitHub Pages). This action is ideal for tracking contributor effort across multiple projects in an organization, whether for open-source volunteer tracking or internal metrics.
+**Org Coding Hours** is a GitHub Action that aggregates **per-contributor coding hours** across one or more repositories. It uses the [`git-hours`](https://github.com/trinhminhtriet/git-hours) utility to estimate how many hours each contributor has spent (based on commit timestamps), and produces JSON summary reports. Optionally, it can also generate a **static HTML dashboard** and publish both the JSON metrics and the site to dedicated branches (for example, to host on GitHub Pages). This action is ideal for tracking contributor effort across multiple projects in an organization, whether for open-source volunteer tracking or internal metrics.
 
 Key features and benefits:
 
@@ -134,22 +134,9 @@ This project uses **semantic versioning** for its action releases (e.g. v1.0.0, 
 
 *(For contributors: if you contribute to this action, the maintainers will handle the tagging and release process. Simply follow conventional commit guidelines (using `feat:`, `fix:`, etc. in commit messages) to help the release notes generation.)*
 
-### Regenerating the git-hours binary
+### Using a different git-hours version
 
-This action includes a prebuilt `git-hours` binary (located in `docker-action/bin/git-hours`). When upstream `git-hours` releases a new version, regenerate this file by:
-
-1. Installing Go 1.24.
-2. Cloning and building the desired tag:
-
-   ```bash
-   git clone --depth 1 --branch <tag> https://github.com/trinhminhtriet/git-hours.git
-   sed -i 's/go 1.24.1/go 1.24/' git-hours/go.mod
-   (cd git-hours && go install .)
-   ```
-
-3. Copying the resulting `git-hours` executable from `$(go env GOBIN)` into `docker-action/bin/git-hours` and committing the change.
-
-This keeps the Docker image in sync with upstream `git-hours` releases.
+The action downloads a prebuilt [`git-hours`](https://github.com/trinhminhtriet/git-hours) binary from the GitHub release assets at runtime. By default, it fetches version `v0.1.2`, but you can select another release by setting the `git_hours_version` input when invoking the action. No manual rebuild of the container is required.
 
 ## Additional Notes and Best Practices
 

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ outputs:
     description: Repositories identifier safe for artifact names (slashes and spaces replaced by underscores)
 runs:
   using: "docker"
-  image: "docker-action/Dockerfile"
+  image: "Dockerfile"
   env:
     REPOS: ${{ inputs.repos }}
     WINDOW_START: ${{ inputs.window_start }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+VERSION="${GIT_HOURS_VERSION:-v0.1.2}"
+URL="https://github.com/trinhminhtriet/git-hours/releases/download/${VERSION}/git-hours_Linux_x86_64.tar.gz"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Download and extract git-hours
+curl -sL "$URL" -o "$TMP_DIR/git-hours.tar.gz"
+tar -xzf "$TMP_DIR/git-hours.tar.gz" -C "$TMP_DIR"
+chmod +x "$TMP_DIR/git-hours"
+mv "$TMP_DIR/git-hours" /usr/local/bin/git-hours
+
+exec /app/OrgCodingHoursCLI "$@"


### PR DESCRIPTION
## Summary
- swap Node git-hours for Go binary fetched from trinhminhtriet/git-hours
- download git-hours at runtime via new entrypoint script
- update documentation and action configuration

## Testing
- `pwsh tests/OrgCodingHoursCLI.Tests.ps1`
- `pwsh tests/OrgCodingHoursCLI.Error.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_688fae9d87b0832993f29e1679aff47c