### PR TITLE
feat: centralize versioning and tag artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   docker-action:
     runs-on: ubuntu-latest
@@ -46,6 +49,8 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+      - name: Extract version
+        run: echo "CLI_VERSION=$(grep -oP '(?<=<Version>).*?(?=</Version>)' version.props)" >> $GITHUB_ENV
       - name: Restore
         run: dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj
       - name: Build
@@ -61,7 +66,14 @@ jobs:
         run: |
           Invoke-Pester
       - name: Pack CLI
-        run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o ./artifacts
+        run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o ./artifacts /p:Version=${CLI_VERSION}
+      - name: Build Docker image
+        run: docker build --build-arg CLI_VERSION=${CLI_VERSION} -t org-coding-hours-action:${CLI_VERSION} .
+      - name: Tag release
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git tag v${CLI_VERSION}
+          git push origin v${CLI_VERSION}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage: compile the .NET 7 console application
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG CLI_VERSION
 WORKDIR /src
 
 # Copy and restore project dependencies
@@ -13,6 +14,10 @@ RUN dotnet publish OrgCodingHoursCLI.csproj -c Release -o /app/out \
 
 # Final runtime image
 FROM node:14-slim AS final
+ARG CLI_VERSION
+LABEL org.opencontainers.image.version=$CLI_VERSION
+# Expose the CLI version for downstream steps
+ENV ORG_CLI_VERSION=$CLI_VERSION
 # Install git, curl, certificates, and nodegit dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git ca-certificates curl libkrb5-dev && rm -rf /var/lib/apt/lists/*

--- a/OrgCodingHoursCLI/OrgCodingHoursCLI.csproj
+++ b/OrgCodingHoursCLI/OrgCodingHoursCLI.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../version.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>

--- a/tests/OrgCodingHoursCLI.Tests.ps1
+++ b/tests/OrgCodingHoursCLI.Tests.ps1
@@ -159,9 +159,10 @@ Describe "OrgCodingHoursCLI" {
 
         Context "Docker image" {
             It "contains the CLI executable" {
-                docker build -t org-hours-test $repoRoot | Out-Null
-                docker run --rm org-hours-test /bin/sh -c 'test -f /app/OrgCodingHoursCLI' | Out-Null
-                docker run --rm org-hours-test --help 2>&1 | Should -Match "REPOS"
+                $version = ([xml](Get-Content (Join-Path $repoRoot 'version.props'))).Project.PropertyGroup.Version
+                docker build --build-arg CLI_VERSION=$version -t "org-hours-test:$version" $repoRoot | Out-Null
+                docker run --rm "org-hours-test:$version" /bin/sh -c 'test -f /app/OrgCodingHoursCLI' | Out-Null
+                docker run --rm "org-hours-test:$version" --help 2>&1 | Should -Match "REPOS"
             }
         }
 

--- a/version.props
+++ b/version.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- centralize CLI version in `version.props`
- reuse version for dotnet pack, Docker build and git tag
- carry version into Docker image metadata

## Testing
- `dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore`
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj`
- `dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o ./artifacts /p:Version=0.1.0`
- `DOTNET_ROOT=/root/.dotnet pwsh -NoLogo -Command "Invoke-Pester"` *(fails: `Username for 'https://github.com':`)*
- `docker build --build-arg CLI_VERSION=0.1.0 -t org-coding-hours-action:0.1.0 .` *(fails: `Cannot connect to the Docker daemon`)*

------
https://chatgpt.com/codex/tasks/task_e_688fcf176fc08329bece1cf1302d90db