### PR TITLE
Cache Pester module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,25 @@ jobs:
         run: dotnet publish OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release
       - name: Run unit tests
         run: dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj
-      - name: Install Pester (latest)
+      - name: Cache PowerShell modules
+        uses: actions/cache@v4
+        with:
+          path: tools/Modules
+          key: ${{ runner.os }}-psmodules-pester-5.5.0
+      - name: Install Pester
         shell: pwsh
         run: |
-          Install-Module -Name Pester -RequiredVersion 5.5.0 -Scope CurrentUser -Force
+          $modulePath = Join-Path $PWD 'tools/Modules'
+          if (-not (Test-Path (Join-Path $modulePath 'Pester' '5.5.0'))) {
+            Save-Module -Name Pester -RequiredVersion 5.5.0 -Path $modulePath -Force
+          }
+          $env:PSModulePath = "$modulePath" + [IO.Path]::PathSeparator + $env:PSModulePath
+          "PSModulePath=$env:PSModulePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Upload Pester module
+        uses: actions/upload-artifact@v4
+        with:
+          name: pester-module
+          path: tools/Modules/Pester/5.5.0
       - name: Run Pester tests
         shell: pwsh
         run: |
@@ -57,10 +72,25 @@ jobs:
         run: dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore
       - name: Run unit tests
         run: dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj
-      - name: Install Pester (latest)
+      - name: Cache PowerShell modules
+        uses: actions/cache@v4
+        with:
+          path: tools/Modules
+          key: ${{ runner.os }}-psmodules-pester-5.5.0
+      - name: Install Pester
         shell: pwsh
         run: |
-          Install-Module -Name Pester -RequiredVersion 5.5.0 -Scope CurrentUser -Force
+          $modulePath = Join-Path $PWD 'tools/Modules'
+          if (-not (Test-Path (Join-Path $modulePath 'Pester' '5.5.0'))) {
+            Save-Module -Name Pester -RequiredVersion 5.5.0 -Path $modulePath -Force
+          }
+          $env:PSModulePath = "$modulePath" + [IO.Path]::PathSeparator + $env:PSModulePath
+          "PSModulePath=$env:PSModulePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Upload Pester module
+        uses: actions/upload-artifact@v4
+        with:
+          name: pester-module
+          path: tools/Modules/Pester/5.5.0
       - name: Run Pester tests
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- cache PowerShell modules and pin Pester version to 5.5.0
- persist downloaded modules in the repo for deterministic workflows

## Testing
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj`
- `pwsh -NoLogo -NoProfile -Command '$modulePath = Join-Path $PWD "tools/Modules"; if (-not (Test-Path (Join-Path $modulePath "Pester" "5.5.0"))) { Save-Module -Name Pester -RequiredVersion 5.5.0 -Path $modulePath -Force }; $env:PSModulePath = "$modulePath" + [IO.Path]::PathSeparator + $env:PSModulePath; Invoke-Pester -Path tests -CI'` *(fails: GitHub authentication prompts)*

------
https://chatgpt.com/codex/tasks/task_e_688fd405eeb483299f6a80d6888ba768