### PR TITLE
Use packaged CLI in runtime image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     name: Run Docker action on sample repo
     steps:
       - uses: actions/checkout@v4
-      - name: Publish CLI
-        run: dotnet publish OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release
+      - name: Pack CLI
+        run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package
       - name: Execute action against Hello-World
         uses: ./
         with:
@@ -32,6 +32,8 @@ jobs:
         run: dotnet publish OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release
       - name: Run unit tests
         run: dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj
+      - name: Pack CLI
+        run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package
       - name: Cache PowerShell modules
         uses: actions/cache@v4
         with:
@@ -99,13 +101,13 @@ jobs:
         shell: pwsh
         run: |
           Invoke-Pester
-      - name: Publish CLI
-        run: dotnet publish OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o cli -r linux-x64 --self-contained true
+      - name: Pack CLI
+        run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package -p:PackageVersion=${{ steps.version.outputs.cli_version }}
       - name: Upload CLI artifact
         uses: actions/upload-artifact@v4
         with:
           name: cli-package
-          path: cli
+          path: package/*.nupkg
 
   docker_build:
     runs-on: ubuntu-latest
@@ -117,7 +119,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: cli-package
-          path: cli
+          path: package
       - name: Build Docker image
         run: docker build --build-arg CLI_VERSION=${{ needs.build_cli.outputs.cli_version }} -t org-coding-hours-action:${{ needs.build_cli.outputs.cli_version }} .
       - name: Tag release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: cli-package
-          path: cli
+          path: package
       - name: Log in to ghcr
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Build image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,29 @@
-FROM node:14-slim
+FROM mcr.microsoft.com/dotnet/runtime:8.0
+
 ARG CLI_VERSION
 LABEL org.opencontainers.image.version=$CLI_VERSION
 # Expose the CLI version for downstream steps
 ENV ORG_CLI_VERSION=$CLI_VERSION
-# Install git, curl, certificates, and nodegit dependencies
+
+# Install git, curl, certificates, node, and unzip
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git ca-certificates curl libkrb5-dev && rm -rf /var/lib/apt/lists/*
+    git ca-certificates curl libkrb5-dev nodejs npm unzip \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install git-hours CLI globally
 RUN npm install -g git-hours@1.5.0
-# Copy the prebuilt .NET application
-COPY cli/ /app
+
+# Copy NuGet package for the CLI produced in CI
+COPY package/OrgCodingHoursCLI*.nupkg /tmp/OrgCodingHoursCLI.nupkg
+
+# Extract CLI assembly
+RUN mkdir /app \
+    && unzip /tmp/OrgCodingHoursCLI.nupkg -d /tmp/cli \
+    && cp /tmp/cli/lib/net8.0/* /app/ \
+    && rm -rf /tmp/cli /tmp/OrgCodingHoursCLI.nupkg
+
 # Set working directory to the GitHub workspace
 WORKDIR /github/workspace
+
 # Run the OrgCodingHoursCLI when the container starts
-ENTRYPOINT ["/app/OrgCodingHoursCLI"]
+ENTRYPOINT ["dotnet", "/app/OrgCodingHoursCLI.dll"]

--- a/tests/OrgCodingHoursCLI.Tests.ps1
+++ b/tests/OrgCodingHoursCLI.Tests.ps1
@@ -161,7 +161,7 @@ Describe "OrgCodingHoursCLI" {
             It "contains the CLI executable" {
                 $version = ([xml](Get-Content (Join-Path $repoRoot 'version.props'))).Project.PropertyGroup.Version
                 docker build --build-arg CLI_VERSION=$version -t "org-hours-test:$version" $repoRoot | Out-Null
-                docker run --rm "org-hours-test:$version" /bin/sh -c 'test -f /app/OrgCodingHoursCLI' | Out-Null
+                docker run --rm "org-hours-test:$version" /bin/sh -c 'test -f /app/OrgCodingHoursCLI.dll' | Out-Null
                 docker run --rm "org-hours-test:$version" --help 2>&1 | Should -Match "REPOS"
             }
         }


### PR DESCRIPTION
## Summary
- install runtime dependencies and extract CLI from packaged artifact
- build workflows use packaged CLI instead of self-contained binary
- align Pester tests with DLL-based CLI in container

## Testing
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj`
- `pwsh -Command "Invoke-Pester"` *(fails: Username for 'https://github.com')*
- `docker build --build-arg CLI_VERSION=0.1.0 -t org-hours-test:0.1.0 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fd9d8ac0483299c03963beed594ef