### PR TITLE
Fix release workflow to reuse build job

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -1,0 +1,36 @@
+name: Build CLI
+
+on:
+  workflow_call:
+    outputs:
+      cli_version:
+        description: 'CLI version'
+        value: ${{ jobs.build_cli.outputs.cli_version }}
+
+jobs:
+  build_cli:
+    runs-on: ubuntu-latest
+    outputs:
+      cli_version: ${{ steps.version.outputs.cli_version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+      - name: Extract version
+        id: version
+        run: echo "cli_version=$(grep -oP '(?<=<Version>).*?(?=</Version>)' version.props)" >> $GITHUB_OUTPUT
+      - name: Restore
+        run: dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj
+      - name: Build
+        run: dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore
+      - name: Run unit tests
+        run: dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj
+      - name: Pack CLI
+        run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package -p:PackageVersion=${{ steps.version.outputs.cli_version }}
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-package
+          path: package/*.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,32 +67,8 @@ jobs:
           Invoke-Pester
 
   build_cli:
-    runs-on: ubuntu-latest
     name: Build and test CLI
-    outputs:
-      cli_version: ${{ steps.version.outputs.cli_version }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '8.0.x'
-      - name: Extract version
-        id: version
-        run: echo "cli_version=$(grep -oP '(?<=<Version>).*?(?=</Version>)' version.props)" >> $GITHUB_OUTPUT
-      - name: Restore
-        run: dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj
-      - name: Build
-        run: dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore
-      - name: Run unit tests
-        run: dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj
-      - name: Pack CLI
-        run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package -p:PackageVersion=${{ steps.version.outputs.cli_version }}
-      - name: Upload CLI artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: cli-package
-          path: package/*.nupkg
+    uses: ./.github/workflows/build-cli.yml
 
   docker_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build_cli:
-    uses: ./.github/workflows/ci.yml#build_cli
+    uses: ./.github/workflows/build-cli.yml
     secrets: inherit
 
   publish_cli:


### PR DESCRIPTION
## Summary
- add reusable workflow to build CLI
- fix release workflow to call reusable build job
- update CI to use new reusable build workflow

## Testing
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj`
- `pwsh -NoLogo -Command '$modulePath = Join-Path $PWD "tools/Modules"; $env:PSModulePath = "$modulePath" + [IO.Path]::PathSeparator + $env:PSModulePath; Invoke-Pester'` *(fails: Go toolchain not found)*

------
https://chatgpt.com/codex/tasks/task_e_689005332d088329ad417ef0d88c064b