### PR TITLE
fix: use lowercase repository in Docker image tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set lowercase repository name
+        run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -101,5 +103,5 @@ jobs:
           build-args: |
             CLI_VERSION=${{ needs.build_cli.outputs.cli_version }}
           tags: |
-            ghcr.io/${{ github.repository }}:${{ needs.build_cli.outputs.cli_version }}
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/${{ env.REPO_LC }}:${{ needs.build_cli.outputs.cli_version }}
+            ghcr.io/${{ env.REPO_LC }}:${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set lowercase repository name
+        run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
       - uses: actions/download-artifact@v4
         with:
           name: cli-package
@@ -39,6 +41,6 @@ jobs:
       - name: Log in to ghcr
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Build image
-        run: docker build --build-arg CLI_VERSION=${{ needs.build_cli.outputs.cli_version }} -t ghcr.io/${{ github.repository }}:${{ needs.build_cli.outputs.cli_version }} .
+        run: docker build --build-arg CLI_VERSION=${{ needs.build_cli.outputs.cli_version }} -t ghcr.io/$REPO_LC:${{ needs.build_cli.outputs.cli_version }} .
       - name: Push image
-        run: docker push ghcr.io/${{ github.repository }}:${{ needs.build_cli.outputs.cli_version }}
+        run: docker push ghcr.io/$REPO_LC:${{ needs.build_cli.outputs.cli_version }}


### PR DESCRIPTION
## Summary
- ensure GHCR image tags use a lowercase repository path

## Testing
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68901982ff388329b2e6023953c99520