### PR TITLE
Fix unit test workflow by restoring test project

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -22,7 +22,9 @@ jobs:
         id: version
         run: echo "cli_version=$(grep -oP '(?<=<Version>).*?(?=</Version>)' version.props)" >> $GITHUB_OUTPUT
       - name: Restore
-        run: dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
+        run: |
+          dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
+          dotnet restore OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --locked-mode
       - name: Build
         run: dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore
       - name: Run unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.302'
-      - name: Restore
-        run: dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
+        - name: Restore
+          run: dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
       - name: Pack CLI
         run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package --no-restore
       - name: Execute action against sample repos
@@ -29,21 +29,23 @@ jobs:
         with:
           repos: ni/labview-icon-editor ni/open-source
 
-  pester-tests:
-    runs-on: ubuntu-latest
-    name: Run Pester tests for CLI
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '8.0.302'
-      - name: Restore
-        run: dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
-      - name: Publish CLI
-        run: dotnet publish OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore
-      - name: Run unit tests
-        run: dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --no-restore
+    pester-tests:
+      runs-on: ubuntu-latest
+      name: Run Pester tests for CLI
+      steps:
+        - uses: actions/checkout@v4
+        - name: Setup .NET
+          uses: actions/setup-dotnet@v3
+          with:
+            dotnet-version: '8.0.302'
+        - name: Restore
+          run: |
+            dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
+            dotnet restore OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --locked-mode
+        - name: Publish CLI
+          run: dotnet publish OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore
+        - name: Run unit tests
+          run: dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --no-restore
       - name: Pack CLI
         run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package --no-restore
       - name: Cache PowerShell modules


### PR DESCRIPTION
## Summary
- restore test project in CI and build workflows before running tests

## Testing
- `dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode && dotnet restore OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --locked-mode`
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_6890234cd5a48329bcbaff16f54ce651