### PR TITLE
Fix unit test workflow by restoring test project

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -22,7 +22,9 @@ jobs:
         id: version
         run: echo "cli_version=$(grep -oP '(?<=<Version>).*?(?=</Version>)' version.props)" >> $GITHUB_OUTPUT
       - name: Restore
-        run: dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
+        run: |
+          dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
+          dotnet restore OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --locked-mode
       - name: Build
         run: dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore
       - name: Run unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_call:
 
 permissions:
@@ -39,7 +39,9 @@ jobs:
         with:
           dotnet-version: '8.0.302'
       - name: Restore
-        run: dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
+        run: |
+          dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
+          dotnet restore OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --locked-mode
       - name: Publish CLI
         run: dotnet publish OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore
       - name: Run unit tests


### PR DESCRIPTION
## Summary
- restore test project in CI and build workflows before running tests
- correct CI workflow YAML formatting so jobs run as intended

## Testing
- `dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode`
- `dotnet restore OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --locked-mode`
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --no-restore`
- `yamllint -d '{extends: default, rules: {document-start: disable, line-length: disable, truthy: disable}}' .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_6890234cd5a48329bcbaff16f54ce651