### PR TITLE
chore: download git binary during build

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.302'
       - name: Extract version
@@ -29,6 +29,8 @@ jobs:
         run: dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore
       - name: Run unit tests
         run: dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --no-restore
+      - name: Fetch git
+        run: ./scripts/fetch-git.sh
       - name: Pack CLI
         run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package -p:PackageVersion=${{ steps.version.outputs.cli_version }} --no-restore
       - name: Upload CLI artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.302'
       - name: Restore
         run: dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
+      - name: Fetch git
+        run: ./scripts/fetch-git.sh
       - name: Pack CLI
         run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package --no-restore
       - name: Execute action against sample repos
@@ -35,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.302'
       - name: Restore
@@ -46,6 +48,8 @@ jobs:
         run: dotnet publish OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore
       - name: Run unit tests
         run: dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --no-restore
+      - name: Fetch git
+        run: ./scripts/fetch-git.sh
       - name: Pack CLI
         run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package --no-restore
       - name: Cache PowerShell modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.302'
       - name: Restore
         run: dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
+      - name: Fetch git
+        run: ./scripts/fetch-git.sh
       - name: Pack CLI
         run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package -p:PackageVersion=${{ needs.build_cli.outputs.cli_version }} --no-restore
       - name: Publish package

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tools/git/

--- a/OrgCodingHoursCLI/OrgCodingHoursCLI.csproj
+++ b/OrgCodingHoursCLI/OrgCodingHoursCLI.csproj
@@ -8,5 +8,8 @@
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="../tools/git/git" Pack="true" PackagePath="tools/git/" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The CLI runs on Windows, macOS, and Linux. Regardless of platform, ensure the fo
 
 - `git`
 
+> The repository doesn't commit a `git` binary. During packaging, the build workflows run a script that downloads a pinned static `git` binary and places it under `tools/git/` for inclusion in the CLI's NuGet package.
+
 ## Inputs
 
 This action supports the following inputs:

--- a/scripts/fetch-git.sh
+++ b/scripts/fetch-git.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GIT_VERSION="2.39.5-0+deb12u2"
+ARCH="amd64"
+URL="https://deb.debian.org/debian/pool/main/g/git/git_${GIT_VERSION}_${ARCH}.deb"
+DEST_DIR="$(dirname "$0")/../tools/git"
+TMP_DIR="$(mktemp -d)"
+
+mkdir -p "$DEST_DIR"
+
+curl -L "$URL" -o "$TMP_DIR/git.deb"
+dpkg-deb -x "$TMP_DIR/git.deb" "$TMP_DIR/extract"
+cp "$TMP_DIR/extract/usr/bin/git" "$DEST_DIR/git"
+chmod +x "$DEST_DIR/git"
+rm -rf "$TMP_DIR"


### PR DESCRIPTION
## Summary
- ignore tools/git directory and fetch git on demand
- add script to download pinned git binary
- use fetch-git in CI workflows and package the binary via csproj
- document that git binary is downloaded during build
- fix CI workflow YAML and update workflows to use setup-dotnet v4

## Testing
- `tools/git/git --version`
- `dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode`
- `dotnet restore OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --locked-mode`
- `dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore`
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --no-restore`
- `dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package --no-restore`
- `pwsh -NoLogo -Command "Install-Module Pester -Force -RequiredVersion 5.5.0; Invoke-Pester"`
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/ci.yml`
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/build-cli.yml`
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/release.yml`


------
https://chatgpt.com/codex/tasks/task_e_6890345809048329a1378bc6a99b9979