### PR TITLE
Ensure git binary fetched before CLI build steps

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -14,6 +14,8 @@ jobs:
       cli_version: ${{ steps.version.outputs.cli_version }}
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch git
+        run: ./scripts/fetch-git.sh
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -29,8 +31,6 @@ jobs:
         run: dotnet build OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore
       - name: Run unit tests
         run: dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --no-restore
-      - name: Fetch git
-        run: ./scripts/fetch-git.sh
       - name: Pack CLI
         run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package -p:PackageVersion=${{ steps.version.outputs.cli_version }} --no-restore
       - name: Upload CLI artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
     name: Run Docker action on sample repo
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch git
+        run: ./scripts/fetch-git.sh
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.302'
       - name: Restore
         run: dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
-      - name: Fetch git
-        run: ./scripts/fetch-git.sh
       - name: Pack CLI
         run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package --no-restore
       - name: Execute action against sample repos
@@ -36,6 +36,8 @@ jobs:
     name: Run Pester tests for CLI
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch git
+        run: ./scripts/fetch-git.sh
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -44,6 +46,8 @@ jobs:
         run: |
           dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
           dotnet restore OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --locked-mode
+      - name: Fetch git
+        run: ./scripts/fetch-git.sh
       - name: Publish CLI
         run: dotnet publish OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release --no-restore
       - name: Run unit tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch git
+        run: ./scripts/fetch-git.sh
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.302'
       - name: Restore
         run: dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode
-      - name: Fetch git
-        run: ./scripts/fetch-git.sh
       - name: Pack CLI
         run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package -p:PackageVersion=${{ needs.build_cli.outputs.cli_version }} --no-restore
       - name: Publish package


### PR DESCRIPTION
## Summary
- fetch git immediately after checkout in build workflow
- fetch git early in CI pester-tests and docker steps
- fetch git prior to restore in release workflow

## Testing
- `actionlint`
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68903b9171f88329b692ebbb112de92e