### PR TITLE
feat: require github_token input

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ jobs:
       - name: Run Org Coding Hours Action
         uses: LabVIEW-Community-CI-CD/org-coding-hours-action@v7
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           repos: ${{ github.event.inputs.repos }}
           window_start: ${{ github.event.inputs.window_start }}
           # metrics_branch: metrics    # (optional) enable branch push for JSON

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
     description: git-hours release tag to use.
     default: v0.1.2
     required: false
+  github_token:
+    description: GitHub token used to authenticate requests.
+    required: true
 outputs:
   aggregated_report:
     description: Path to the aggregated JSON report file
@@ -29,4 +32,4 @@ runs:
     WINDOW_START: ${{ inputs.window_start }}
     METRICS_BRANCH: ${{ inputs.metrics_branch }}
     GIT_HOURS_VERSION: ${{ inputs.git_hours_version }}
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GITHUB_TOKEN: ${{ inputs.github_token }}


### PR DESCRIPTION
## Summary
- require explicit github_token input
- document github_token usage in README

## Testing
- `dotnet test` *(fails: Could not copy the file `/workspace/org-coding-hours-action/tools/git/git` because it was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890450dbba88329940cb85ae5b7037b