### PR TITLE
Document CLI/Docker usage and add automatic tagging

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,37 @@
+name: Tag release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch tags
+        run: git fetch --tags
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(grep -oP '(?<=<Version>)[^<]+' version.props)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Check tag
+        id: check
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Create tag and release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+          gh release create "v${{ steps.version.outputs.version }}" --generate-notes

--- a/README.md
+++ b/README.md
@@ -97,6 +97,77 @@ jobs:
           path: reports/
 ```
 
+### CLI usage
+
+#### Run locally
+
+Build the CLI and execute it on your machine. The tool reads its configuration
+from environment variables:
+
+```bash
+dotnet publish OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o cli
+export REPOS="my-org/repo1 my-org/repo2"
+export WINDOW_START="2024-01-01"    # optional
+export METRICS_BRANCH="metrics"      # optional
+export GITHUB_TOKEN="ghp_..."        # needed for private repos
+./cli/OrgCodingHoursCLI
+```
+
+#### Run inside a workflow
+
+You can also invoke the published executable from a workflow step:
+
+```yaml
+jobs:
+  cli-example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build CLI
+        run: dotnet publish OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o cli
+      - name: Run CLI
+        run: |
+          export REPOS="my-org/repo1 my-org/repo2"
+          export WINDOW_START="2024-01-01"
+          export METRICS_BRANCH="metrics"
+          ./cli/OrgCodingHoursCLI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Docker usage
+
+#### Run locally
+
+Pull the published image and provide the required environment variables:
+
+```bash
+docker run --rm \
+  -e REPOS="my-org/repo1 my-org/repo2" \
+  -e GITHUB_TOKEN="$GITHUB_TOKEN" \
+  -e WINDOW_START="2024-01-01" \
+  -e METRICS_BRANCH="metrics" \
+  ghcr.io/labview-community-ci-cd/org-coding-hours-action:v0.1.0
+```
+
+Replace `v0.1.0` with the version defined in `version.props`.
+
+#### Run inside a workflow
+
+```yaml
+jobs:
+  docker-example:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Org Coding Hours via Docker
+        uses: docker://ghcr.io/labview-community-ci-cd/org-coding-hours-action:v0.1.0
+        env:
+          REPOS: my-org/repo1 my-org/repo2
+          WINDOW_START: "2024-01-01"
+          METRICS_BRANCH: metrics
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ### Using a different git-hours version
 
 The Docker image includes `git-hours` built from its latest tagged release. To use another revision, rebuild the Docker image with a different `GIT_HOURS_VERSION` build argument or provide your own `git-hours` binary.


### PR DESCRIPTION
## Summary
- document how to run the CLI locally and in workflows
- show how to use the published Docker image
- automate tag creation and releases on pushes to `main`

## Testing
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689049026af4832989fe7ae919e38059