### PR TITLE
chore: skip duplicate package publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Pack CLI
         run: dotnet pack OrgCodingHoursCLI/OrgCodingHoursCLI.csproj -c Release -o package -p:PackageVersion=${{ needs.build_cli.outputs.cli_version }} --no-restore
       - name: Publish package
-        run: dotnet nuget push package/*.nupkg --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json --api-key ${{ secrets.GITHUB_TOKEN }}
+        run: dotnet nuget push package/*.nupkg --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
 
   docker:
     needs: build_cli


### PR DESCRIPTION
## Summary
- add `--skip-duplicate` to release workflow NuGet push to avoid failing when version already exists

## Testing
- `./scripts/fetch-git.sh`
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68905393377c8329891bea2941d7ece9