### PR TITLE
Read version from git tags

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -20,9 +20,22 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.302'
-      - name: Extract version
+      - name: Determine version from ref
         id: version
-        run: echo "cli_version=$(grep -oP '(?<=<Version>).*?(?=</Version>)' version.props)" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          else
+            VERSION="0.0.0"
+          fi
+          echo "cli_version=$VERSION" >> "$GITHUB_OUTPUT"
+          cat <<EOF > version.props
+<Project>
+  <PropertyGroup>
+    <Version>$VERSION</Version>
+  </PropertyGroup>
+</Project>
+EOF
       - name: Restore
         run: |
           dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
+    tags:
+      - "v*"
   pull_request:
     branches: [main]
   workflow_call:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    tags:
+      - "v*"
 
 permissions:
   contents: write
@@ -48,32 +49,12 @@ jobs:
         run: docker build --build-arg CLI_VERSION=${{ needs.build_cli.outputs.cli_version }} -t ghcr.io/$REPO_LC:${{ needs.build_cli.outputs.cli_version }} .
       - name: Push image
         run: docker push ghcr.io/$REPO_LC:${{ needs.build_cli.outputs.cli_version }}
-
-  tag_release:
+  create_release:
     needs: [publish_cli, docker]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Fetch tags
-        run: git fetch --tags
-      - name: Read version
-        id: version
-        run: |
-          VERSION=$(grep -oP '(?<=<Version>)[^<]+' version.props)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Check tag
-        id: check
-        run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Create tag and release
-        if: steps.check.outputs.exists == 'false'
+      - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git tag "v${{ steps.version.outputs.version }}"
-          git push origin "v${{ steps.version.outputs.version }}"
-          gh release create "v${{ steps.version.outputs.version }}" --generate-notes
+        run: gh release create "${{ github.ref_name }}" --generate-notes

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ docker run --rm \
   ghcr.io/labview-community-ci-cd/org-coding-hours-action:v0.1.0
 ```
 
-Replace `v0.1.0` with the version defined in `version.props`.
+Replace `v0.1.0` with the desired release tag.
 
 #### Run inside a workflow
 

--- a/version.props
+++ b/version.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.0</Version>
+    <!-- Version is populated from the Git tag during build -->
+    <Version>0.0.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- infer version from `github.ref` and write to `version.props`
- release and CI workflows trigger on tags rather than branch pushes
- remove need to manually update version.props and update docs

## Testing
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj`
- `pwsh -NoLogo -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689058ec4b008329ab69ad9fb539aed8