### PR TITLE
Fix indentation in build-cli workflow

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -30,12 +30,12 @@ jobs:
           fi
           echo "cli_version=$VERSION" >> "$GITHUB_OUTPUT"
           cat <<EOF > version.props
-<Project>
-  <PropertyGroup>
-    <Version>$VERSION</Version>
-  </PropertyGroup>
-</Project>
-EOF
+          <Project>
+            <PropertyGroup>
+              <Version>$VERSION</Version>
+            </PropertyGroup>
+          </Project>
+          EOF
       - name: Restore
         run: |
           dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode


### PR DESCRIPTION
## Summary
- ensure here-doc for version file is indented inside run block

## Testing
- `python - <<'PY'
import yaml,sys
for p in ['.github/workflows/ci.yml', '.github/workflows/release.yml']:
    with open(p) as f:
        yaml.safe_load(f)
print('parsed')
PY`
- `python - <<'PY'
import yaml
for p in ['.github/workflows/build-cli.yml']:
    yaml.safe_load(open(p))
print('parsed build-cli')
PY`
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68905bd522fc83299c962a281d7beed5