### PR TITLE
Strip tag prefix and limit CI triggers

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -25,17 +25,18 @@ jobs:
         run: |
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             VERSION="${GITHUB_REF#refs/tags/}"
+            VERSION="${VERSION#v}"
           else
             VERSION="0.0.0"
           fi
           echo "cli_version=$VERSION" >> "$GITHUB_OUTPUT"
           cat <<EOF > version.props
-<Project>
-  <PropertyGroup>
-    <Version>$VERSION</Version>
-  </PropertyGroup>
-</Project>
-EOF
+          <Project>
+            <PropertyGroup>
+              <Version>$VERSION</Version>
+            </PropertyGroup>
+          </Project>
+          EOF
       - name: Restore
         run: |
           dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches: [main]
-    tags:
-      - "v*"
   pull_request:
     branches: [main]
   workflow_call:


### PR DESCRIPTION
## Summary
- remove optional `v` prefix from tag-derived version
- run CI only on branch pushes instead of tags

## Testing
- `python - <<'PY'\nimport yaml\nfor p in ['.github/workflows/build-cli.yml', '.github/workflows/ci.yml', '.github/workflows/release.yml']:\n    with open(p) as f:\n        yaml.safe_load(f)\nprint('parsed')\nPY`
- `dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode`
- `dotnet restore OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --locked-mode`
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --no-restore` *(fails: Could not copy the file "/workspace/org-coding-hours-action/tools/git/git" because it was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68905bd522fc83299c962a281d7beed5