### PR TITLE
Fix build CLI workflow heredoc delimiter

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -30,7 +30,7 @@ jobs:
             VERSION="0.0.0"
           fi
           echo "cli_version=$VERSION" >> "$GITHUB_OUTPUT"
-          cat <<EOF > version.props
+          cat <<'EOF' > version.props
           <Project>
             <PropertyGroup>
               <Version>$VERSION</Version>


### PR DESCRIPTION
## Summary
- properly delimit version.props heredoc in build-cli workflow

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 200}}}' .github/workflows/build-cli.yml`
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689064d1ec1c832994c8fea95a555848