### PR TITLE
fix: expand VERSION in build workflow

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -30,13 +30,13 @@ jobs:
             VERSION="0.0.0"
           fi
           echo "cli_version=$VERSION" >> "$GITHUB_OUTPUT"
-          cat <<'EOF' > version.props
-          <Project>
-            <PropertyGroup>
-              <Version>$VERSION</Version>
-            </PropertyGroup>
-          </Project>
-          EOF
+            cat <<EOF > version.props
+            <Project>
+              <PropertyGroup>
+                <Version>$VERSION</Version>
+              </PropertyGroup>
+            </Project>
+            EOF
       - name: Restore
         run: |
           dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode


### PR DESCRIPTION
## Summary
- ensure version.props uses numeric VERSION in build CLI workflow

## Testing
- `dotnet restore OrgCodingHoursCLI/OrgCodingHoursCLI.csproj --locked-mode`
- `dotnet restore OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --locked-mode`
- `dotnet test OrgCodingHoursCLI.Tests/OrgCodingHoursCLI.Tests.csproj --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_689066abbd548329bdd06dd22e339ebd